### PR TITLE
Feature/add warning for multiple cat classes

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -126,7 +126,7 @@ lflt_basic_choropleth <- function(l) {
     color_map <- pal(l$d@data[["b"]])
 
     fill_opacity <- l$theme$topo_fill_opacity
-    if (is(l$d$b, "character")){
+    if (is(l$d$c, "numeric")){
       fill_opacity <- scales::rescale(l$d$c, to = c(0.5, 1))
     }
 
@@ -239,7 +239,10 @@ lflt_basic_bubbles <- function(l) {
                  fillColor = color_map)
   if (!is.null(l$data)) {
 
-    if (is(l$d$b, "character")){
+    radius <- 0
+    color <- l$theme$palette_colors[1]
+
+    if (is(l$d$c, "numeric")){
       radius <- scales::rescale(l$d$c, to = c(l$min_size, l$max_size))
       opts_pal <- list(color_scale = l$color_scale,
                        palette = l$theme$palette_colors,
@@ -249,9 +252,18 @@ lflt_basic_bubbles <- function(l) {
                        n_quantile = l$n_quantile)
       pal <- lflt_palette(opts_pal)
       color <- pal(l$d@data[["b"]])
-    } else {
+    } else if (is(l$d$b, "numeric")){
       radius <- scales::rescale(l$d$b, to = c(l$min_size, l$max_size))
-      color <- l$theme$palette_colors[1]
+    } else if (is(l$d$b, "character")){
+      radius <- ifelse(!is.na(l$d$b), 5, 0)
+      opts_pal <- list(color_scale = l$color_scale,
+                       palette = l$theme$palette_colors,
+                       na_color = l$theme$na_color,
+                       domain = l$d@data[["b"]],
+                       n_bins = l$n_bins,
+                       n_quantile = l$n_quantile)
+      pal <- lflt_palette(opts_pal)
+      color <- pal(l$d@data[["b"]])
     }
 
 

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -73,7 +73,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
       d <- summarizeData(d, opts$summarize$agg, to_agg = b, a) %>% drop_na()}
 
     if (frtype_d %in% c("Gcd-Cat-Num", "Gnm-Cat-Num")) {
-      d_agg <- summarizeData(d, opts$summarize$agg, to_agg = c, a, b) %>% drop_na(a)
+      d_agg <- summarizeData(d, opts$summarize$agg, to_agg = c, a, b) %>% mutate(a = na_if(a, "-99")) %>% drop_na(a)
 
       tooltips <- d_agg %>%
         mutate(html_row = paste0("<span style='font-size:15px;'><strong>", b, ":</strong> ", c, "</span>")) %>%
@@ -87,6 +87,10 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
         dplyr::mutate(d = n(), b = ifelse(d == 1, b, "tie")) %>%
         dplyr::distinct(a, b, c) %>%
         left_join(tooltips, by = "a")
+
+      if(nrow(d) < nrow(d_agg)){
+        warning("Multiple categorical classes found for at least one geography. Data to be shown on map will be based on majority class.")
+      }
 
     }
 

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -37,21 +37,32 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
         }
 
     if (frtype_d %in% c("Gnm-Cat", "Gcd-Cat")) {
-      d <- d %>%
+      d_agg <- d %>%
         drop_na(a) %>%
         dplyr::group_by_all() %>%
-        dplyr::summarise(c = n()) %>%
+        dplyr::summarise(c = n())
+
+      tooltips <- d_agg %>%
+        mutate(html_row_unique = paste0("<strong>", nms[[2]], ":</strong> ", b, "</span>")) %>%
+        group_by(a) %>%
+        summarise(d = ifelse(n()>1,
+                             paste0("<strong>", nms[[2]], ":</strong> ", paste0(b, collapse = "/"), "</span>"),
+                             html_row_unique)) %>%
+        mutate(d = paste0("<span style='font-size:15px;'><strong>", nms[[1]], ":</strong> ",a, "<br/>", d))
+
+      d <- d_agg %>%
         dplyr::filter(c == max(c)) %>%
         dplyr::group_by(a) %>%
         dplyr::mutate(d = n(), b = ifelse(d == 1, b, "tie")) %>%
-        dplyr::distinct(a, b, c)
+        dplyr::distinct(a, b) %>%
+        left_join(tooltips, by = "a")
 
-        ind_nms <- length(nms)+1
-        nms[ind_nms] <- 'Count'
-        names(nms) <- c(names(nms)[-ind_nms], 'c')
-        dic_num <- data.frame(id = "c", label = "Count", hdType= as_hdType(x = "Num"))
-        dic <- dic %>% bind_rows(dic_num)
+      if(nrow(d) < nrow(d_agg)){
+        warning("Multiple categorical classes found for at least one geography.
+                Geographies are colored based on majority class and all counts are displayed in tooltips.
+                Potential ties are indicated by new category 'tie'.")
         }
+      }
 
     if (frtype_d %in% "Gln-Glt-Cat") {
       d <- d %>%
@@ -76,10 +87,11 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
       d_agg <- summarizeData(d, opts$summarize$agg, to_agg = c, a, b) %>% mutate(a = na_if(a, "-99")) %>% drop_na(a)
 
       tooltips <- d_agg %>%
-        mutate(html_row = paste0("<span style='font-size:15px;'><strong>", b, ":</strong> ", c, "</span>")) %>%
+        mutate(html_row_unique = paste0("<strong>", nms[[2]], ":</strong> ", b, "<br/><strong>", nms[[3]], ":</strong> ", c),
+               html_row = paste0("<strong>", b, ":</strong> ", c)) %>%
         group_by(a) %>%
-        summarise(d = paste0(html_row, collapse = "<br/>")) %>%
-        mutate(d = paste0("<span style='font-size:15px;'><strong>", nms[[1]], ":</strong> ",a, "</span>", "<br/>", d))
+        summarise(d = ifelse(n()>1, paste0(html_row, collapse = "<br/>"), html_row_unique)) %>%
+        mutate(d = paste0("<span style='font-size:15px;'><strong>", nms[[1]], ":</strong> ",a, "<br/>", d, "</span>"))
 
       d <- d_agg %>%
         dplyr::group_by(a) %>%
@@ -89,7 +101,9 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
         left_join(tooltips, by = "a")
 
       if(nrow(d) < nrow(d_agg)){
-        warning("Multiple categorical classes found for at least one geography. Data to be shown on map will be based on majority class.")
+        warning("Multiple categorical classes found for at least one geography.
+                Geographies are colored based on majority class and all counts are displayed in tooltips.
+                Potential ties are indicated by new category 'tie'.")
       }
 
     }
@@ -136,16 +150,11 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
     }
     topoInfo@data <- lflt_format(topoInfo@data, dic, nms, opts$style)
 
-    if (frtype_d %in% c("Gcd-Cat-Num", "Gnm-Cat-Num")) {
+    if (frtype_d %in% c("Gcd-Cat-Num", "Gnm-Cat-Num","Gnm-Cat", "Gcd-Cat")) {
       topoInfo@data <- topoInfo@data %>%
         mutate(labels = ifelse(is.na(a), glue::glue("<span style='font-size:13px;'><strong>{name}</strong></span>") %>%
                                  lapply(htmltools::HTML), d %>% lapply(htmltools::HTML))
         )
-      # topoInfo@data <- topoInfo@data %>%
-      #   mutate(labels = ifelse(is.na(a), glue::glue("<span style='font-size:13px;'><strong>{name}</strong></span>") %>%
-      #                            lapply(htmltools::HTML),
-      #                          glue::glue(lflt_tooltip(nms, tooltip = opts$chart$tooltip)) %>% lapply(htmltools::HTML))
-      #   )
     } else {
       topoInfo@data <- topoInfo@data %>%
         mutate(labels = ifelse(is.na(a), glue::glue("<span style='font-size:13px;'><strong>{name}</strong></span>") %>%


### PR DESCRIPTION
- add warning for multiple categorical classes
- add tooltip improvement to `gnm-cat`/`gcd-cat` (before it was only in `gnm-cat-num`/`gcd-cat-num`)
- add same warning for `gnm-cat`/`gcd-cat`
- improve behaviour of scaling of bubble sizes and polygon colours 