### PR TITLE
Feature/add custom cutoffs

### DIFF
--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -177,6 +177,12 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
                               ';color:', opts$theme$legend_color,
                               ';font-size:', opts$theme$legend_size,"px;'>", opts$title$legend_title %||% "","</p>"))
 
+  if(color_scale == "Custom" & is.null(opts$extra$map_cutoff_points)){
+    warning("No cutoff points specified for color scale 'Custom', overwriting color scale with default 'Numeric'.
+            To use custom colorS scale, please define custoff points in parameter 'map_cutoff_points'.")
+    color_scale <- "Numeric"
+  }
+
   list(
     d = topoInfo,
     data = data,
@@ -185,6 +191,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ...) {
     border_color = opts$theme$border_color,
     n_quantile = opts$extra$map_quantile,
     n_bins = opts$extra$map_bins,
+    cutoff_points = opts$extra$map_cutoff_points,
     na_label = opts$preprocess$na_label,
     suffix = opts$style$suffix,
     prefix = opts$style$prefix,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,4 @@
+#' Create cutoff points for legends for bubbles maps
 create_legend_cuts <- function(x, number=seq(1:10)) {
   x_min <- min(x, na.rm = T)
   x_max <- max(x, na.rm = T)
@@ -7,4 +8,19 @@ create_legend_cuts <- function(x, number=seq(1:10)) {
     warning("Legend only displays positive numbers.")
   }
   cuts
+}
+
+#' Calculate custom intervals when map_color_scale = "Custom"
+calculate_custom_intervals <- function(cutoff_points, domain) {
+  min_cutoff <- min(cutoff_points, na.rm = T)
+  max_cutoff <- max(cutoff_points, na.rm = T)
+  min_domain <- min(domain, na.rm = T)
+  max_domain <- max(domain, na.rm = T)
+  if(min_cutoff < min_domain | max_cutoff > max_domain){
+    warning("At least one of the custom cutoff points is outside of the domain.")
+  }
+  if(min_cutoff > min_domain){cutoff_points <- c(min_domain, cutoff_points)}
+  if(max_cutoff < max_domain){cutoff_points <- c(cutoff_points, max_domain)}
+  intervals <- cut(domain, breaks=cutoff_points, include.lowest=TRUE, dig.lab = 5)
+  intervals
 }

--- a/inst/examples.R
+++ b/inst/examples.R
@@ -19,20 +19,20 @@ lflt_choropleth_GcdCat(sample_data("Gcd-Cat", 100))
 
 ## bubbles
 ### numerical data
-lflt_bubbles_GnmNum(sample_data("Gnm-Num", 100)) #
-lflt_bubbles_Gnm(sample_data("Gnm", 100)) #
-lflt_bubbles_GcdNum(sample_data("Gcd-Num", 100)) #
-lflt_bubbles_Gcd(sample_data("Gcd", 100)) #
-lflt_bubbles_GlnGltNum(sample_data("Gln-Glt-Num", 100)) #
-lflt_bubbles_GlnGlt(sample_data("Gln-Glt", 100)) #
+lflt_bubbles_GnmNum(sample_data("Gnm-Num", 100))
+lflt_bubbles_Gnm(sample_data("Gnm", 100))
+lflt_bubbles_GcdNum(sample_data("Gcd-Num", 100))
+lflt_bubbles_Gcd(sample_data("Gcd", 100))
+lflt_bubbles_GlnGltNum(sample_data("Gln-Glt-Num", 100))
+lflt_bubbles_GlnGlt(sample_data("Gln-Glt", 100))
 
 ### categorical data
-lflt_bubbles_GnmCatNum(sample_data("Gnm-Cat-Num", 100)) # size missing
-lflt_bubbles_GnmCat(sample_data("Gnm-Cat", 100)) # size missing
-lflt_bubbles_GcdCatNum(sample_data("Gcd-Cat-Num", 100)) # size missing
-lflt_bubbles_GcdCat(sample_data("Gcd-Cat", 100)) # size missing
-lflt_bubbles_GlnGltCatNum(sample_data("Gln-Glt-Cat-Num", 100)) # size missing
-lflt_bubbles_GlnGltCat(sample_data("Gln-Glt-Cat", 100)) # size missing
+lflt_bubbles_GnmCatNum(sample_data("Gnm-Cat-Num", 100))
+lflt_bubbles_GnmCat(sample_data("Gnm-Cat", 100))
+lflt_bubbles_GcdCatNum(sample_data("Gcd-Cat-Num", 100))
+lflt_bubbles_GcdCat(sample_data("Gcd-Cat", 100))
+lflt_bubbles_GlnGltCatNum(sample_data("Gln-Glt-Cat-Num", 100))
+lflt_bubbles_GlnGltCat(sample_data("Gln-Glt-Cat", 100))
 
 # Gnm-Num examples --------------------------------------------------------
 


### PR DESCRIPTION
Note: Needs PR datasketch/dsvizopts#15 to be merged to function.

Adding option to define custom cutoff points for coloring of choropleth maps. This now works with the following command:

`lflt_choropleth_GcdNum(sample_data("Gcd-Num", 100), map_color_scale = "Custom", map_cutoff_points = c(800, 1200, 1500))`

![image](https://user-images.githubusercontent.com/59022602/88400922-a9709800-cd8e-11ea-8fa4-884de658e9e2.png)
