### PR TITLE
add hover highlights to choropleth maps

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -137,7 +137,12 @@ lflt_basic_choropleth <- function(l) {
                  opacity = 1,
                  label = ~name,
                  color = l$border_color,
-                 fillColor = color_map)
+                 fillColor = color_map,
+                 highlight = highlightOptions(
+                   color= 'white',
+                   opacity = 0.8,
+                   weight= 3,
+                   bringToFront = TRUE))
 
   if (!is.null(l$data)) {
     if(sum(is.na(l$d@data$b)) == nrow(l$d@data)) {
@@ -172,7 +177,12 @@ lflt_basic_choropleth <- function(l) {
                    color = l$border_color,
                    fillColor = color_map,
                    layerId = ~a,
-                   label = ~labels
+                   label = ~labels,
+                   highlight = highlightOptions(
+                     color= 'white',
+                     opacity = 0.8,
+                     weight= 3,
+                     bringToFront = TRUE)
       )
     if (!is.null(l$data) & l$theme$legend_show) {
 


### PR DESCRIPTION
Add highlights to choropleth maps that appear for mouse hover:

![image](https://user-images.githubusercontent.com/59022602/88568720-04a8c180-cfff-11ea-8250-84061c06f2d4.png)
