### PR TITLE
Update handling of palettes in prep

### DIFF
--- a/R/bubbles_GnmCatNum.R
+++ b/R/bubbles_GnmCatNum.R
@@ -13,7 +13,7 @@
 lflt_bubbles_GnmCatNum <- function(data = NULL, ...) {
   opts <- dsvizopts::merge_dsviz_options(...)
 
-  l <- lfltmagic_prep(data = data, opts = opts)
+  l <- lfltmagic_prep(data = data, opts = opts, ftype = "Gnm-Cat-Num")
 
   lf <- lflt_basic_bubbles(l) %>%
     lflt_background(l$theme) %>%

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,6 +1,5 @@
 #' Legend by palette type
 lflt_palette <- function(opts) {
-  palette <- opts$palette
   if (opts$color_scale %in% c("Category", "Custom")) {
     color_mapping <- "colorFactor"
     # l <- list(levels = opts$levels,
@@ -14,12 +13,11 @@ lflt_palette <- function(opts) {
     l <- list(bins = opts$n_bins,
               pretty = opts$pretty)
   } else {
-    palette <- opts$sequential
     color_mapping <- "colorNumeric"
     l <- list()
   }
 
-  l$palette <- palette
+  l$palette <- opts$palette
   l$domain <- opts$domain
   l$na.color <- opts$na_color
   do.call(color_mapping, l)
@@ -146,9 +144,9 @@ lflt_basic_choropleth <- function(l) {
 
 
       opts_pal <- list(color_scale = l$color_scale,
-                       palette = l$theme$palette_colors,
-                       sequential = l$theme$palette_colors_sequential,
-                       divergent = l$theme$palette_colors_divergent,
+                       palette = l$palette_colors,
+                       # sequential = l$palette_colors_sequential,
+                       # divergent = l$palette_colors_divergent,
                        na_color = l$theme$na_color,
                        domain = domain,
                        n_bins = l$n_bins,
@@ -213,13 +211,13 @@ lflt_basic_points <- function(l) {
   if (!is.null(l$data)) {
 
     radius <- 0
-    color <- l$theme$palette_colors[1]
+    color <- l$palette_colors[1]
     legend_color <- color
 
     if (is(l$d$d, "numeric")){
       radius <- scales::rescale(l$d$d, to = c(l$min_size, l$max_size))
       opts_pal <- list(color_scale = l$color_scale,
-                       palette = l$theme$palette_colors,
+                       palette = l$palette_colors,
                        na_color = l$theme$na_color,
                        domain = l$d@data[["c"]],
                        n_bins = l$n_bins,
@@ -234,7 +232,7 @@ lflt_basic_points <- function(l) {
     } else if (is(l$d$c, "character")){
       radius <- ifelse(!is.na(l$d$c), 5, 0)
       opts_pal <- list(color_scale = l$color_scale,
-                       palette = l$theme$palette_colors,
+                       palette = l$palette_colors,
                        na_color = l$theme$na_color,
                        domain = l$d@data[["c"]],
                        n_bins = l$n_bins,
@@ -311,13 +309,13 @@ lflt_basic_bubbles <- function(l) {
   if (!is.null(l$data)) {
 
     radius <- 0
-    color <- l$theme$palette_colors[1]
+    color <- l$palette_colors[1]
     legend_color <- color
 
     if (is(l$d$c, "numeric")){
       radius <- scales::rescale(l$d$c, to = c(l$min_size, l$max_size))
       opts_pal <- list(color_scale = l$color_scale,
-                       palette = l$theme$palette_colors,
+                       palette = l$palette_colors,
                        na_color = l$theme$na_color,
                        domain = l$d@data[["b"]],
                        n_bins = l$n_bins,
@@ -332,7 +330,7 @@ lflt_basic_bubbles <- function(l) {
     } else if (is(l$d$b, "character")){
       radius <- ifelse(!is.na(l$d$b), 5, 0)
       opts_pal <- list(color_scale = l$color_scale,
-                       palette = l$theme$palette_colors,
+                       palette = l$palette_colors,
                        na_color = l$theme$na_color,
                        domain = l$d@data[["b"]],
                        n_bins = l$n_bins,

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -31,7 +31,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
 
 
     frtype_d <- paste0(dic$hdType, collapse = "-")
-    if (sum(grepl("Cat", dic$hdType))>1) color_scale <- "Category"
+    if (sum(grepl("Cat", dic$hdType))>0) color_scale <- "Category"
 
     if (grepl("Pct", frtype_d)) {
       dic$hdType[dic$hdType == "Pct"] <- "Num"

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -51,7 +51,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
 
 
     frtype_d <- paste0(dic$hdType, collapse = "-")
-    if (sum(grepl("Cat", dic$hdType))>1) color_scale <- "Category"
+    if (sum(grepl("Cat", dic$hdType))>0) color_scale <- "Category"
 
     if (grepl("Pct", frtype_d)) {
       dic$hdType[dic$hdType == "Pct"] <- "Num"

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -11,6 +11,8 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
   bbox <- topoInfo@bbox
   if (is.null(bbox)) bbox <- topo_bbox(centroides$lon, centroides$lat)
   color_scale <- opts$extra$map_color_scale
+  palette_colors <-  opts$theme$palette_colors
+  palette_type <-  opts$theme$palette_type
 
   if (is.null(data)) {
     topoInfo@data <- topoInfo@data %>%
@@ -23,15 +25,33 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
     dic <- fringe_dic(f, id_letters = T)
     pre_ftype <- strsplit(ftype, "-") %>% unlist()
 
-    if (length(dic$hdType) == 1) {
-      dic$hdType <- pre_ftype[1]
+    if(length(pre_ftype) < length(dic$hdType)){
+      if(!all(pre_ftype == dic$hdType[1:length(pre_ftype)])){
+        warning("Input data types differ from expected data types.")
+        dic$hdType[1:length(pre_ftype)] <- pre_ftype
+      }
+    } else if(length(pre_ftype) > length(dic$hdType)){
+      if(!all(pre_ftype[1:length(dic$hdType)] == dic$hdType)){
+        warning("Input data types differ from expected data types.")
+        dic$hdType <- pre_ftype[1:length(dic$hdType)]
+      }
     } else {
-      dic$hdType[1:length(pre_ftype)] <- pre_ftype
+      if(!all(pre_ftype == dic$hdType)){
+        warning("Input data types differ from expected data types.")
+        dic$hdType <- pre_ftype
+      }
     }
+    #
+    #
+    # if (length(dic$hdType) == 1) {
+    #   dic$hdType <- pre_ftype[1]
+    # } else {
+    #   dic$hdType[1:length(pre_ftype)] <- pre_ftype
+    # }
 
 
     frtype_d <- paste0(dic$hdType, collapse = "-")
-    if (sum(grepl("Cat", dic$hdType))>0) color_scale <- "Category"
+    if (sum(grepl("Cat", dic$hdType))>1) color_scale <- "Category"
 
     if (grepl("Pct", frtype_d)) {
       dic$hdType[dic$hdType == "Pct"] <- "Num"
@@ -135,18 +155,17 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
 
 
     data <- d
-  }
+
 
   # define color palette based on data type
-  palette_type <-  opts$theme$palette_type
   var_cat <- "Cat" %in% dic$hdType
   if(!is.null(palette_type)){
     if(!palette_type %in% c("categorical", "sequential", "divergent")){
       warning("Palette type must be one of 'categorical', 'sequential', or 'divergent'; reverting to default.")
       palette_type <- NULL
     }
-    if(!var_cat & palette_type == "categorical"){
-      warning("Palette type might not be suitable for data type input.")
+    if(!var_cat & palette_type == "categorical" | (var_cat & palette_type %in% c("sequential", "divergent"))){
+      warning("Palette type might not be suitable for data type.")
     }
   } else {
     if(var_cat){
@@ -156,7 +175,6 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
     }
   }
 
-  palette_colors <-  opts$theme$palette_colors
   if(is.null(palette_colors)){
     if(palette_type == "categorical"){
       palette_colors <- opts$theme$palette_colors_categorical
@@ -166,7 +184,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
       palette_colors <- opts$theme$palette_colors_divergent
     }
   }
-
+  }
 
   # style titles
   title <- tags$div(HTML(paste0("<div style='margin-bottom:0px;font-family:", opts$theme$text_family,

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -69,12 +69,10 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
       dic <- dic %>% bind_rows(dic_num)
     }
 
-
     var_cats <- grep("Cat|Gcd|Gnm", dic$hdType)
     var_nums <- grep("Num|Glt|Gln", dic$hdType)
 
     # category, geocode, geoname formtat
-
 
     if (!identical(var_cats, integer())) {
       var_cats <- dic$id_letters[var_cats]
@@ -139,7 +137,38 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
     data <- d
   }
 
+  # define color palette based on data type
+  palette_type <-  opts$theme$palette_type
+  var_cat <- "Cat" %in% dic$hdType
+  if(!is.null(palette_type)){
+    if(!palette_type %in% c("categorical", "sequential", "divergent")){
+      warning("Palette type must be one of 'categorical', 'sequential', or 'divergent'; reverting to default.")
+      palette_type <- NULL
+    }
+    if(!var_cat & palette_type == "categorical"){
+      warning("Palette type might not be suitable for data type input.")
+    }
+  } else {
+    if(var_cat){
+      palette_type <- "categorical"
+    } else {
+      palette_type <- "sequential"
+    }
+  }
 
+  palette_colors <-  opts$theme$palette_colors
+  if(is.null(palette_colors)){
+    if(palette_type == "categorical"){
+      palette_colors <- opts$theme$palette_colors_categorical
+    } else if (palette_type == "sequential"){
+      palette_colors <- opts$theme$palette_colors_sequential
+    } else if (palette_type == "divergent"){
+      palette_colors <- opts$theme$palette_colors_divergent
+    }
+  }
+
+
+  # style titles
   title <- tags$div(HTML(paste0("<div style='margin-bottom:0px;font-family:", opts$theme$text_family,
                                 ';color:', opts$theme$title_color,
                                 ';font-size:', opts$theme$title_size,"px;'>", opts$title$title %||% "","</div>")))
@@ -159,6 +188,7 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
     data = data,
     b_box = bbox,
     color_scale = color_scale,
+    palette_colors = palette_colors,
     titles = list(title = title,
                   subtitle = subtitle,
                   caption = caption),


### PR DESCRIPTION
Merge after merging datasketch/dsvizopts#20 to update handling of color palettes.

The latest update in `dsvizopts` introduced a new parameter `palette_type` (default = `NULL`) and changed the default of `palette_colors` to be `NULL`.

Assigning color palettes in this package now works as follows:

The parameter `palette_type` is assigned in the prep function depending on the data type if not defined by user input. If the user input is not one of  `categorical`, `sequential`, or `divergent` a warning is raised and the default option based on the data type is used instead.

The parameter `palette_colors` is defined in the prep function depending on the value of `palette_type`. 
