### PR TITLE
Fix data processing for gnm-cat and gcd-cat

### DIFF
--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -94,11 +94,17 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
         drop_na(a) %>%
         dplyr::group_by_all() %>%
         dplyr::summarise(c = n())
-      frtype_d <- paste0(frtype_d, "-Num")
-      nms[3] <- opts$summarize$agg_text %||% "Count"
-      names(nms) <- c("a", "b", "c")
-      dic_num <- data.frame(id = "count", label = "Count", hdType= as_hdType(x = "Num"), id_letters = "c")
-      dic <- dic %>% bind_rows(dic_num)
+
+      if(sum(d$c) > nrow(d)){
+        frtype_d <- paste0(frtype_d, "-Num")
+        nms[3] <- opts$summarize$agg_text %||% "Count"
+        names(nms) <- c("a", "b", "c")
+        dic_num <- data.frame(id = "count", label = "Count", hdType= as_hdType(x = "Num"), id_letters = "c")
+        dic <- dic %>% bind_rows(dic_num)
+      } else {
+        d <- d %>% select(-c)
+      }
+
     }
 
     var_cats <- grep("Cat|Gcd|Gnm", dic$hdType)


### PR DESCRIPTION
Fixing data processing for `Gnm-Cat` and `Gcd-Cat`, so that a `count` column is only added to the data when there are multiple rows for the same country in the data.