### PR TITLE
Fix extra tooltip column

### DIFF
--- a/R/choropleth_GnmCatNum.R
+++ b/R/choropleth_GnmCatNum.R
@@ -37,4 +37,16 @@ lflt_choropleth_GnmCatNum <- function(data = NULL, ...) {
 #' @export
 #' @examples
 #' lflt_choropleth_GnmCat(sample_data("Gnm-Cat", nrow = 10))
-lflt_choropleth_GnmCat <- lflt_choropleth_GnmCatNum
+lflt_choropleth_GnmCat <- function(data = NULL, ...) {
+  opts <- dsvizopts::merge_dsviz_options(...)
+
+  l <- lfltmagic_prep(data = data, opts = opts, ftype = "Gnm-Cat")
+
+  lf <- lflt_basic_choropleth(l) %>%
+    lflt_background(l$theme) %>%
+    lflt_bounds(l$b_box) %>%
+    lflt_graticule(l$graticule) %>%
+    lflt_titles(l$titles)
+
+  lf
+}

--- a/R/lfltmagic_prep.R
+++ b/R/lfltmagic_prep.R
@@ -41,13 +41,6 @@ lfltmagic_prep <- function(data = NULL, opts = NULL, by_col = "name", ftype="Gnm
         dic$hdType <- pre_ftype
       }
     }
-    #
-    #
-    # if (length(dic$hdType) == 1) {
-    #   dic$hdType <- pre_ftype[1]
-    # } else {
-    #   dic$hdType[1:length(pre_ftype)] <- pre_ftype
-    # }
 
 
     frtype_d <- paste0(dic$hdType, collapse = "-")


### PR DESCRIPTION
For maps of data types `Gnm-Cat` and `Gcd-Cat` it was not possible to pass extra columns to the `lflt_..` functions to display in the tooltip. This was fixed in this PR.